### PR TITLE
Wrap POST /token_auths API

### DIFF
--- a/fixture/vcr_cassettes/token_auths_request.json
+++ b/fixture/vcr_cassettes/token_auths_request.json
@@ -1,0 +1,36 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Authorization": "***"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://api.localhost.local:3000/token_auths"
+    },
+    "response": {
+      "body": "{\"token_auth\":{\"token_type\":\"card\",\"token\":\"45393cd06fedd253405eccaa4bd8f10d\",\"user_id\":\"457dd2d8a401fa19693b0c04f0128eb0\"}}",
+      "headers": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Origin, Content-Type, Accept, Authorization, Token",
+        "Access-Control-Allow-Methods": "POST, GET, PUT, DELETE, OPTIONS",
+        "Access-Control-Max-Age": "1728000",
+        "Access-Control-Request-Method": "*",
+        "Content-Type": "application/json; charset=utf-8",
+        "ETag": "W/\"87842bd470a86f4f2f826e758174850f\"",
+        "Cache-Control": "max-age=0, private, must-revalidate",
+        "X-Request-Id": "8c4d316d-9628-468a-b83e-a639831c9b41",
+        "X-Runtime": "0.186656",
+        "Connection": "close",
+        "Server": "thin"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/promisepay_ex.ex
+++ b/lib/promisepay_ex.ex
@@ -107,4 +107,20 @@ defmodule PromisepayEx do
 
   """
   defdelegate item(id), to: PromisepayEx.API.Items
+
+  @doc """
+  Generates token.
+
+  POST /token_auths
+  ## Reference
+
+      https://reference.assemblypayments.com/#token-auth
+
+  ## Examples
+
+      options = %{token_type: "card", user_id: "user_id"}
+      PromisepayEx.generate_token(options)
+
+  """
+  defdelegate generate_token(params), to: PromisepayEx.API.Token
 end

--- a/lib/promisepay_ex/api/token.ex
+++ b/lib/promisepay_ex/api/token.ex
@@ -1,0 +1,15 @@
+defmodule PromisepayEx.API.Token do
+  @moduledoc """
+  Generates token.
+  """
+
+  import PromisepayEx.API.Base
+  alias PromisepayEx.Parser
+
+  @spec generate_token(Keyword.t) :: Keyword.t
+  def generate_token(options) do
+    params = Parser.parse_request_params(options)
+    %{token_auth: token_auth} = request(:post, "token_auths", params)
+    Parser.parse_token(token_auth)
+  end
+end

--- a/lib/promisepay_ex/client.ex
+++ b/lib/promisepay_ex/client.ex
@@ -6,9 +6,16 @@ defmodule PromisepayEx.Client do
   @doc """
   Send request with get method.
   """
-  @spec request(:get, String.t, Keyword.t, String.t, String.t) :: Map.t
-  def request(:get, url, params, username, password) do
-    perform_get(url, params, username, password)
+  @spec request(Keyword.t, String.t, Keyword.t, String.t, String.t) :: Map.t
+  def request(method, url, params, username, password) do
+    case method do
+      :get ->
+        perform_get(url, params, username, password)
+      :post ->
+        perform_post(url, params, username, password)
+      _ ->
+        # TODO
+    end
   end
 
   def perform_get(_url, _params, nil, nil) do
@@ -58,5 +65,43 @@ defmodule PromisepayEx.Client do
 
   defp build_params(params, url) do
     to_char_list(url <> "?" <> params)
+  end
+
+  def perform_post(_url, _params, nil, nil) do
+    raise(PromisepayEx.Error, message: "Error")
+  end
+
+  @spec perform_post(String.t, Keyword.t, String.t, String.t) :: Map.t
+  def perform_post(url, params, username, password) do
+    params
+    |> URI.encode_query
+    |> build_params(url)
+    |> send_post_request(username, password)
+  end
+
+  defp send_post_request(request, username, password) do
+    headers = build_authorization_header(username, password)
+    response = HTTPoison.post(request, "", headers)
+
+    case response do
+      {
+        :ok,
+        %HTTPoison.Response{
+          status_code: 200,
+          body: body,
+          headers: headers
+        }
+      } ->
+        {:ok, {200, headers, body}}
+      {:ok, %HTTPoison.Response{status_code: 422}} ->
+        {:error, "Not Found"}
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, reason}
+    end
+  end
+
+  defp build_authorization_header(username, password) do
+    header = "Basic " <> Base.encode64(username <> ":" <> password)
+    [{"Authorization", header}]
   end
 end

--- a/lib/promisepay_ex/model.ex
+++ b/lib/promisepay_ex/model.ex
@@ -51,3 +51,18 @@ defmodule PromisepayEx.Model.Item do
 
   @type t :: %__MODULE__{}
 end
+
+defmodule PromisepayEx.Model.Token do
+  @moduledoc """
+  Token object.
+
+  ## Reference
+  https://reference.promisepay.com/#token_auth
+  """
+
+  defstruct token_type: nil,
+            token: nil,
+            user_id: nil
+
+  @type t :: %__MODULE__{}
+end

--- a/lib/promisepay_ex/parser.ex
+++ b/lib/promisepay_ex/parser.ex
@@ -18,4 +18,12 @@ defmodule PromisepayEx.Parser do
   def parse_request_params(options) do
     Enum.map(options, fn({k,v}) -> {to_string(k), to_string(v)} end)
   end
+
+  @doc """
+  Parse token record from the API response json.
+  """
+  @spec parse_token(Map.t) :: Map.t
+  def parse_token(object) do
+    struct(PromisepayEx.Model.Token, object)
+  end
 end

--- a/test/promisepay_ex_test.exs
+++ b/test/promisepay_ex_test.exs
@@ -1,4 +1,6 @@
 defmodule PromisepayExTest do
+  @moduledoc false
+
   use ExUnit.Case
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
   doctest PromisepayEx
@@ -69,6 +71,20 @@ defmodule PromisepayExTest do
       item = PromisepayEx.item("6bf802c5e641aeaf28ac4397eb5f42a5")
       assert item.name == "Awesome Websites Domain"
       assert item.id == "6bf802c5e641aeaf28ac4397eb5f42a5"
+    end
+  end
+
+  test "authenticated token_auths request" do
+    Config.filter_request_headers("Authorization")
+
+    use_cassette "token_auths_request" do
+      options = %{
+        token_type: "card",
+        user_id: "064d6800-fff3-11e5-86aa-5e5517507c66"
+      }
+      token = PromisepayEx.generate_token(options)
+      assert token.token == "45393cd06fedd253405eccaa4bd8f10d"
+      assert token.user_id == "457dd2d8a401fa19693b0c04f0128eb0"
     end
   end
 end


### PR DESCRIPTION
This implements wrapper method for **`POST /token_auths`** API. 

Example Call:
```elixir
PromisepayEx.configure(
  username: "j.doe@example.com",
  password: "secret"
)

token = PromisepayEx.generate_token(token_type: "card", user_id: "user_id")
```